### PR TITLE
Drop byteorder dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,3 @@ readme = "README.md"
 repository = "https://github.com/johannesvollmer/lz4-compression-rs"
 
 [dependencies]
-byteorder = "1.3.1"

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -4,7 +4,7 @@
 //! high performance. It has fixed memory usage, which contrary to other approachs, makes it less
 //! memory hungry.
 
-use byteorder::{NativeEndian, ByteOrder};
+use std::convert::TryInto;
 
 /// Duplication dictionary size.
 ///
@@ -115,7 +115,7 @@ impl<'a> Encoder<'a> {
     fn get_batch(&self, n: usize) -> u32 {
         debug_assert!(self.remaining_batch(), "Reading a partial batch.");
 
-        NativeEndian::read_u32(&self.input[n..])
+        u32::from_ne_bytes(self.input[n..n+4].try_into().unwrap())
     }
 
     /// Read the batch at the cursor.

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -1,6 +1,6 @@
 //! The decompression algorithm.
 
-use byteorder::{LittleEndian, ByteOrder};
+use std::convert::TryInto;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum Error {
@@ -117,8 +117,9 @@ impl<'a> Decoder<'a> {
     /// Read a little-endian 16-bit integer from the input stream.
     #[inline]
     fn read_u16(&mut self) -> Result<u16, Error> {
-        // We use byteorder to read an u16 in little endian.
-        Ok(LittleEndian::read_u16(self.take(2)?))
+        // Read a u16 in little endian.
+        let bytes = self.take(2)?;
+        Ok(u16::from_le_bytes(bytes.try_into().unwrap()))
     }
 
     /// Read the literals section of a block.


### PR DESCRIPTION
Drop unnecessary byteorder dependency. Reduces compilation time and removes all unsafe code from the dependency tree.

There are no benchmarks in this repo, but in other projects I've seen this pattern optimize similarly to or better than byteorder.

Requires Rust 1.34, but that has been released so long ago that it's present even in Debian Oldstable.