### PR TITLE
Add fuzzing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,3 @@ readme = "README.md"
 repository = "https://github.com/johannesvollmer/lz4-compression-rs"
 
 [dependencies]
-byteorder = "1.3.1"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+
+[package]
+name = "lz4-compression-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.lz4-compression]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "decompress"
+path = "fuzz_targets/decompress.rs"
+
+[[bin]]
+name = "roundtrip"
+path = "fuzz_targets/roundtrip.rs"

--- a/fuzz/fuzz_targets/decompress.rs
+++ b/fuzz/fuzz_targets/decompress.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use lz4_compression::decompress::decompress;
+
+fuzz_target!(|data: &[u8]| {
+    decompress(data);
+});

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use lz4_compression::decompress::decompress;
+use lz4_compression::compress::compress;
+
+fuzz_target!(|data: &[u8]| {
+    let compressed = compress(data);
+    let decompressed = decompress(&compressed).expect("Failed to decompress what we've compressed");
+    assert!(decompressed.as_slice() == data, "Decompressed data is different from the original");
+});

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -4,7 +4,7 @@
 //! high performance. It has fixed memory usage, which contrary to other approachs, makes it less
 //! memory hungry.
 
-use byteorder::{NativeEndian, ByteOrder};
+use std::convert::TryInto;
 
 /// Duplication dictionary size.
 ///
@@ -115,7 +115,7 @@ impl<'a> Encoder<'a> {
     fn get_batch(&self, n: usize) -> u32 {
         debug_assert!(self.remaining_batch(), "Reading a partial batch.");
 
-        NativeEndian::read_u32(&self.input[n..])
+        u32::from_ne_bytes(self.input[n..n+4].try_into().unwrap())
     }
 
     /// Read the batch at the cursor.

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -1,6 +1,6 @@
 //! The decompression algorithm.
 
-use byteorder::{LittleEndian, ByteOrder};
+use std::convert::TryInto;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum Error {
@@ -117,8 +117,9 @@ impl<'a> Decoder<'a> {
     /// Read a little-endian 16-bit integer from the input stream.
     #[inline]
     fn read_u16(&mut self) -> Result<u16, Error> {
-        // We use byteorder to read an u16 in little endian.
-        Ok(LittleEndian::read_u16(self.take(2)?))
+        // Read a u16 in little endian.
+        let bytes = self.take(2)?;
+        Ok(u16::from_le_bytes(bytes.try_into().unwrap()))
     }
 
     /// Read the literals section of a block.


### PR DESCRIPTION
This PR depends on #2, please review that first.

Use `cargo-fuzz` to verify that:

1. Decoding arbitrary data does not cause panics or infinite loops
2. We can decode arbitrary data we've encoded

I've run both for about an hour and found no bugs.